### PR TITLE
Enable orthanc auth to deployment in production

### DIFF
--- a/.docker/Nginx-Orthanc/config/nginx.conf
+++ b/.docker/Nginx-Orthanc/config/nginx.conf
@@ -37,6 +37,7 @@ http {
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Host $server_name;
+            rewrite /orthanc(.*) $1 break;
 
             # CORS Magic
             add_header 'Access-Control-Allow-Origin' '*';

--- a/.docker/Nginx-Orthanc/config/orthanc.json
+++ b/.docker/Nginx-Orthanc/config/orthanc.json
@@ -30,9 +30,10 @@
   "RemoteAccessAllowed": true,
   "SslEnabled": false,
   "SslCertificate": "certificate.pem",
-  "AuthenticationEnabled": false,
+  "AuthenticationEnabled": true,
   "RegisteredUsers": {
-    "test": "test"
+    "test": "test",
+    "admin":"${PRODUCTION_PWD}"
   },
   "DicomModalities": {},
   "DicomModalitiesInDatabase": false,
@@ -47,7 +48,7 @@
   "HttpVerbose": true,
 
   "HttpTimeout": 10,
-  "HttpsVerifyPeers": true,
+	  "HttpsVerifyPeers": true,
   "HttpsCACertificates": "",
   "UserMetadata": {},
   "UserContentType": {},

--- a/.docker/Nginx-Orthanc/docker-compose.yml
+++ b/.docker/Nginx-Orthanc/docker-compose.yml
@@ -13,3 +13,12 @@ services:
       - '4242:4242' # DICOM
       - '8042:8042' # Web
     restart: unless-stopped
+  web:
+    image: nginx
+    volumes:
+      - ./config/nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - '8080:80'
+    environment:
+      - NGINX_HOST=localhost
+      - NGINX_PORT=80

--- a/.docker/Viewer-v2.x/docker-compose.yml
+++ b/.docker/Viewer-v2.x/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.5'
+
+services:
+  viewers:
+    image: node:16-alpine
+    hostname: viewers
+    working_dir: /home/node/app
+    environment:
+      - NODE_ENV=production
+    volumes:
+      - ./../../:/home/node/app
+    ports:
+      - '3000:3000' # web
+    command: npm start --production
+    restart: unless-stopped

--- a/platform/core/src/DICOMSR/handleStructuredReport.js
+++ b/platform/core/src/DICOMSR/handleStructuredReport.js
@@ -74,7 +74,7 @@ const stowSRFromMeasurements = async (measurements, serverUrl) => {
 
   const config = {
     url: serverUrl,
-    headers: DICOMWeb.getAuthorizationHeader(),
+    headers: DICOMWeb.getAuthorizationHeader(appConfig.servers.dicomWeb[0]),
     errorInterceptor: errorHandler.getHTTPErrorHandler(),
     requestHooks: [getXHRRetryRequestHook()],
   };

--- a/platform/viewer/public/config/default.js
+++ b/platform/viewer/public/config/default.js
@@ -8,15 +8,19 @@ window.config = {
   servers: {
     dicomWeb: [
       {
-        name: 'DCM4CHEE',
-        wadoUriRoot: 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/wado',
-        qidoRoot: 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs',
-        wadoRoot: 'https://server.dcmjs.org/dcm4chee-arc/aets/DCM4CHEE/rs',
-        qidoSupportsIncludeField: true,
+        name: 'Orthanc',
+        wadoUriRoot: 'http://127.0.0.1:8080/wado',
+        qidoRoot: 'http://127.0.0.1:8080/dicom-web',
+        wadoRoot: 'http://127.0.0.1:8080/dicom-web',
+        qidoSupportsIncludeField: false,
         imageRendering: 'wadors',
         thumbnailRendering: 'wadors',
-        enableStudyLazyLoad: true,
-        supportsFuzzyMatching: true,
+	      requestOptions: {
+        // undefined to use JWT + Bearer auth
+          auth: (_options) => {
+            return `${PRODUCTION_PWD_AUTH}`
+          }
+        },
       },
     ],
   },

--- a/platform/viewer/src/config.js
+++ b/platform/viewer/src/config.js
@@ -44,7 +44,7 @@ export function setConfiguration(appConfig) {
 
   cornerstoneWADOImageLoader.configure({
     beforeSend: function(xhr) {
-      const headers = OHIF.DICOMWeb.getAuthorizationHeader();
+      const headers = OHIF.DICOMWeb.getAuthorizationHeader(appConfig.servers.dicomWeb[0]);
 
       if (headers.Authorization) {
         xhr.setRequestHeader('Authorization', headers.Authorization);


### PR DESCRIPTION
### PR Checklist

- fixes to docker compose scripts to deployment
- enable basic authentication for orthanc as a pacs
- changes only outstanding for OHIF/edxsalud fork
